### PR TITLE
Add interval_mode to rtr_init

### DIFF
--- a/rtrlib.cdef
+++ b/rtrlib.cdef
@@ -634,7 +634,8 @@ struct rtr_socket {
 int rtr_init(struct rtr_socket *rtr_socket, struct tr_socket *tr_socket, struct pfx_table *pfx_table,
              struct spki_table *spki_table, const unsigned int refresh_interval,
              const unsigned int expire_interval, const unsigned int retry_interval,
-             rtr_connection_state_fp fp, void *fp_data_config, void *fp_data_group);
+             enum interval_mode iv_mode, rtr_connection_state_fp fp, void *fp_data_config, 
+             void *fp_data_group);
 
 /**
  * @brief Starts the RTR protocol state machine in a pthread. Connection to the rtr_server will be established and the


### PR DESCRIPTION
I tried building from source but kept getting the following error

```
build/temp.macosx-10.13-x86_64-3.6/_rtrlib.c:2543:57: error: too few arguments
      to function call, expected 11, have 10
  return rtr_init(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9);
         ~~~~~~~~                                       ^
/usr/local/include/rtrlib/rtr/rtr.h:190:1: note: 'rtr_init' declared here
int rtr_init(struct rtr_socket *rtr_socket, struct tr_socket *tr_socke...
^
build/temp.macosx-10.13-x86_64-3.6/_rtrlib.c:2659:61: error: too few arguments
      to function call, expected 11, have 10
  { result = rtr_init(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9); }
             ~~~~~~~~                                       ^
/usr/local/include/rtrlib/rtr/rtr.h:190:1: note: 'rtr_init' declared here
int rtr_init(struct rtr_socket *rtr_socket, struct tr_socket *tr_socke...
^
2 errors generated.
```

so I had a look at the header files for the latest rtr_init, added the missing interval_mode and now it compiles and `python3 rtrclient.py tcp rpki-validator.realmv6.org 8282` is working
