### PR TITLE
Add PfxTable wrapper class

### DIFF
--- a/rtrlib.cdef
+++ b/rtrlib.cdef
@@ -421,6 +421,56 @@ typedef void (*pfx_update_fp)(struct pfx_table *pfx_table, const struct pfx_reco
 typedef void (*pfx_for_each_fp)(const struct pfx_record *pfx_record, void *data);
 
 /**
+ * @brief pfx_table.
+ * @param ipv4
+ * @param ipv6
+ * @param update_fp
+ * @param lock
+ */
+struct pfx_table {
+	struct trie_node *ipv4;
+	struct trie_node *ipv6;
+	pfx_update_fp update_fp;
+	...;
+};
+
+/**
+ * @brief Initializes the pfx_table struct.
+ * @param[in] pfx_table pfx_table that will be initialized.
+ * @param[in] update_fp A function pointer that will be called if a record was added or removed.
+ */
+void pfx_table_init(struct pfx_table *pfx_table, pfx_update_fp update_fp);
+
+/**
+ * @brief Frees all memory associated with the pfx_table.
+ * @param[in] pfx_table pfx_table that will be freed.
+ */
+void pfx_table_free(struct pfx_table *pfx_table);
+
+/**
+ * @brief Adds a pfx_record to a pfx_table.
+ * @param[in] pfx_table pfx_table to use.
+ * @param[in] pfx_record pfx_record that will be added.
+ * @return PFX_SUCCESS On success.
+ * @return PFX_ERROR On error.
+ * @return PFX_DUPLICATE_RECORD If the pfx_record already exists.
+ */
+int pfx_table_add(struct pfx_table *pfx_table, const struct pfx_record *pfx_record);
+
+/**
+ * @brief Validates the origin of a BGP-Route.
+ * @param[in] pfx_table pfx_table to use.
+ * @param[in] asn Autonomous system number of the Origin-AS of the route.
+ * @param[in] prefix Announced network Prefix.
+ * @param[in] mask_len Length of the network mask of the announced prefix.
+ * @param[out] result Result of the validation.
+ * @return PFX_SUCCESS On success.
+ * @return PFX_ERROR On error.
+ */
+int pfx_table_validate(struct pfx_table *pfx_table, const uint32_t asn, const struct lrtr_ip_addr *prefix,
+		       const uint8_t mask_len, enum pfxv_state *result);
+
+/**
  * @brief Validates the origin of a BGP-Route and returns a list of pfx_record that decided the result.
  * @param[in] pfx_table pfx_table to use.
  * @param[out] reason Pointer to a memory area that will be used as array of pfx_records. The memory area will be overwritten. Reason must point to NULL or an allocated memory area.

--- a/rtrlib.cdef
+++ b/rtrlib.cdef
@@ -458,6 +458,16 @@ void pfx_table_free(struct pfx_table *pfx_table);
 int pfx_table_add(struct pfx_table *pfx_table, const struct pfx_record *pfx_record);
 
 /**
+ * @brief Removes a pfx_record from a pfx_table.
+ * @param[in] pfx_table pfx_table to use.
+ * @param[in] pfx_record Record that will be removed.
+ * @return PFX_SUCCESS On success.
+ * @return PFX_ERROR On error.
+ * @return PFX_RECORD_NOT_FOUND If pfx_records couldn't be found.
+ */
+int pfx_table_remove(struct pfx_table *pfx_table, const struct pfx_record *pfx_record);
+
+/**
  * @brief Validates the origin of a BGP-Route.
  * @param[in] pfx_table pfx_table to use.
  * @param[in] asn Autonomous system number of the Origin-AS of the route.

--- a/rtrlib/__init__.py
+++ b/rtrlib/__init__.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, unicode_literals
 
 import logging
 
+from .pfx_table import PfxTable
 from .rtr_manager import RTRManager, PfxvState
 from .manager_group import ManagerGroupStatus
 

--- a/rtrlib/pfx_table.py
+++ b/rtrlib/pfx_table.py
@@ -29,6 +29,20 @@ class PfxTable(object):
                            ffi.NULL)
         self.closed = False
 
+    @classmethod
+    def _create_pfx_record(cls, asn, ip, min_length, max_length):
+        record = ffi.new('struct pfx_record *')
+        prefix = ffi.new('struct lrtr_ip_addr *')
+        lib.lrtr_ip_str_to_addr(ip.encode('ascii'), prefix)
+
+        record.asn = asn
+        record.min_len = min_length
+        record.max_len = max_length
+        record.socket = ffi.NULL
+        record.prefix = prefix[0]
+
+        return record
+
     def add_record(self, asn, ip, min_length, max_length):
         """
         Add a BGP prefix to the table.
@@ -46,15 +60,7 @@ class PfxTable(object):
         :type max_length: int
         """
 
-        record = ffi.new('struct pfx_record *')
-        prefix = ffi.new('struct lrtr_ip_addr *')
-        lib.lrtr_ip_str_to_addr(ip.encode('ascii'), prefix)
-
-        record.asn = asn
-        record.min_len = min_length
-        record.max_len = max_length
-        record.socket = ffi.NULL
-        record.prefix = prefix[0]
+        record = self._create_pfx_record(asn, ip, min_length, max_length)
 
         lib.pfx_table_add(self.pfx_table, record)
 
@@ -75,15 +81,7 @@ class PfxTable(object):
         :type max_length: int
         """
 
-        record = ffi.new('struct pfx_record *')
-        prefix = ffi.new('struct lrtr_ip_addr *')
-        lib.lrtr_ip_str_to_addr(ip.encode('ascii'), prefix)
-
-        record.asn = asn
-        record.min_len = min_length
-        record.max_len = max_length
-        record.socket = ffi.NULL
-        record.prefix = prefix[0]
+        record = self._create_pfx_record(asn, ip, min_length, max_length)
 
         lib.pfx_table_remove(self.pfx_table, record)
 

--- a/rtrlib/pfx_table.py
+++ b/rtrlib/pfx_table.py
@@ -1,0 +1,178 @@
+# -*- coding: utf8 -*-
+"""
+rtrlib.rtr_manager
+------------------
+
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+
+from .exceptions import PFXException
+from .rtr_manager import ValidationResult
+from .util import ip_str_to_addr
+
+from _rtrlib import ffi, lib
+
+
+class PfxTable(object):
+    """
+    Wrapper class around pfx_table.
+
+    """
+
+    def __init__(self):
+        # allocate pfx_table
+        self.pfx_table = ffi.new('struct pfx_table *')
+        # initialize it
+        lib.pfx_table_init(self.pfx_table,
+                           ffi.NULL)
+        self.closed = False
+
+    def add_record(self, asn, ip, min_length, max_length):
+        """
+        Add a BGP prefix to the table.
+
+        :param asn: autonomous system number
+        :type asn: int
+
+        :param ip: ip address
+        :type ip: str
+
+        :param min_length: minimum length of the subnet mask
+        :type min_length: int
+
+        :param max_length: minimum length of the subnet mask
+        :type max_length: int
+        """
+
+        record = ffi.new('struct pfx_record *')
+        prefix = ffi.new('struct lrtr_ip_addr *')
+        lib.lrtr_ip_str_to_addr(ip.encode('ascii'), prefix)
+
+        record.asn = asn
+        record.min_len = min_length
+        record.max_len = max_length
+        record.socket = ffi.NULL
+        record.prefix = prefix[0]
+
+        lib.pfx_table_add(self.pfx_table, record)
+
+    def remove_record(self, asn, ip, min_length, max_length):
+        """
+        Add a BGP prefix to the table.
+
+        :param asn: autonomous system number
+        :type asn: int
+
+        :param ip: ip address
+        :type ip: str
+
+        :param min_length: minimum length of the subnet mask
+        :type min_length: int
+
+        :param max_length: minimum length of the subnet mask
+        :type max_length: int
+        """
+
+        record = ffi.new('struct pfx_record *')
+        prefix = ffi.new('struct lrtr_ip_addr *')
+        lib.lrtr_ip_str_to_addr(ip.encode('ascii'), prefix)
+
+        record.asn = asn
+        record.min_len = min_length
+        record.max_len = max_length
+        record.socket = ffi.NULL
+        record.prefix = prefix[0]
+
+        lib.pfx_table_remove(self.pfx_table, record)
+
+    def validate(self, asn, prefix, mask_len):
+        """
+        Validate BGP prefix and returns state as ValidationResult object.
+        The reason list in the returned result will be empty.
+
+        :param asn: autonomous system number
+        :type asn: int
+
+        :param prefix: ip address
+        :type prefix: str
+
+        :param mask_len: length of the subnet mask
+        :type mask_len: int
+
+        :rtype: ValidationResult
+        """
+
+        result = ffi.new('enum pfxv_state *')
+
+        ret = lib.pfx_table_validate(self.pfx_table,
+                                     asn,
+                                     ip_str_to_addr(prefix),
+                                     mask_len,
+                                     result)
+
+        if ret == lib.PFX_ERROR:
+            raise PFXException("An error occurred during validation")
+
+        return ValidationResult(prefix,
+                                mask_len,
+                                asn,
+                                result[0])
+
+    def validate_r(self, asn, prefix, mask_len):
+        """
+        Validate BGP prefix and returns state as ValidationResult object.
+        The reason list in the returned result will contain a list of Reason objects.
+
+        :param asn: autonomous system number
+        :type asn: int
+
+        :param prefix: ip address
+        :type prefix: str
+
+        :param mask_len: length of the subnet mask
+        :type mask_len: int
+
+        :rtype: ValidationResult
+        """
+
+        result = ffi.new('enum pfxv_state *')
+
+        reason = ffi.new('struct pfx_record **')
+        reason[0] = ffi.NULL
+        reason_length = ffi.new('unsigned int *')
+        reason_length[0] = 0
+
+        ret = lib.pfx_table_validate_r(self.pfx_table,
+                                       reason,
+                                       reason_length,
+                                       asn,
+                                       ip_str_to_addr(prefix),
+                                       mask_len,
+                                       result)
+
+        if ret == lib.PFX_ERROR:
+            raise PFXException("An error occurred during validation")
+
+        return ValidationResult(prefix,
+                                mask_len,
+                                asn,
+                                result[0],
+                                reason,
+                                reason_length[0])
+
+    def close(self):
+        if not self.closed:
+            lib.pfx_table_free(self.pfx_table)
+            self.closed = True
+
+    def __enter__(self):
+        return self
+
+    def __del__(self):
+        self.close()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False

--- a/rtrlib/pfx_table.py
+++ b/rtrlib/pfx_table.py
@@ -29,8 +29,8 @@ class PfxTable(object):
                            ffi.NULL)
         self.closed = False
 
-    @classmethod
-    def _create_pfx_record(cls, asn, ip, min_length, max_length):
+    @staticmethod
+    def _create_pfx_record(asn, ip, min_length, max_length):
         record = ffi.new('struct pfx_record *')
         lib.lrtr_ip_str_to_addr(ip.encode('ascii'), ffi.addressof(record, 'prefix'))
 

--- a/rtrlib/pfx_table.py
+++ b/rtrlib/pfx_table.py
@@ -32,14 +32,12 @@ class PfxTable(object):
     @classmethod
     def _create_pfx_record(cls, asn, ip, min_length, max_length):
         record = ffi.new('struct pfx_record *')
-        prefix = ffi.new('struct lrtr_ip_addr *')
-        lib.lrtr_ip_str_to_addr(ip.encode('ascii'), prefix)
+        lib.lrtr_ip_str_to_addr(ip.encode('ascii'), ffi.addressof(record, 'prefix'))
 
         record.asn = asn
         record.min_len = min_length
         record.max_len = max_length
         record.socket = ffi.NULL
-        record.prefix = prefix[0]
 
         return record
 

--- a/rtrlib/rtr_manager.py
+++ b/rtrlib/rtr_manager.py
@@ -468,7 +468,7 @@ class ValidationResult(object):
             for record in ffi.unpack(reason_records[0], reason_len):
                 self._reason.append(Reason(prefix_length, asn, record))
 
-        elif (not ffi.typeof(reason_records) is ffi.typeof('struct pfx_record **')):
+        elif (reason_records and not ffi.typeof(reason_records) is ffi.typeof('struct pfx_record **')):
             raise TypeError("reason_records must be struct pfx_record **")
         else:
             self._reason = None


### PR DESCRIPTION
Hi,

Our use case for integrating the rtrlib is that we already have the ROAS data available locally from another system and only need the validation part.
So I added a pxf_table wrapper class to have a nice simle API at hand.

Note: This pull-request rquires pullrequest #13 . You might want to first review and integrate that one.

Best regards and have nice Xmas days,
Michael