### PR TITLE
Conditional dependency to module 'enum34': Ony for python_version < "3.4.0"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,9 @@ setup(
     ),
     setup_requires=["cffi>=1.6.0"],
     cffi_modules=["ffi_build.py:ffibuilder"],
-    install_requires=["cffi>=1.6.0", "six", 'enum34'],
+    install_requires=[
+        "cffi>=1.6.0",
+        "six",
+        'enum34; python_version < "3.4.0"'
+    ],
 )


### PR DESCRIPTION
The current master of rtrlib/python-binding may cause pip installations to fail on Python versions 3.6 - 3.8 because of the dependency to module [enum34](https://pypi.org/project/enum34/). This dependency is not needed for Python 3.4 and above.

This is a [known issue with pip](https://github.com/pypa/pip/issues/8214) and seems to be fixed only recently (2020-12).

Since e.g. default Python version on Ubuntu 20.04 LTS is 3.8, where the issue will still be present, I think this project should guard against pip installation fails by adding a version contition to the dependency.

